### PR TITLE
Comment out the ESO installation via subchart

### DIFF
--- a/common/golang-external-secrets/Chart.yaml
+++ b/common/golang-external-secrets/Chart.yaml
@@ -4,8 +4,8 @@ keywords:
 - pattern
 name: golang-external-secrets
 version: 0.0.1
-dependencies:
-  - name: external-secrets
-    version: "0.6.1"
-    repository: "https://charts.external-secrets.io"
-    #"https://external-secrets.github.io/kubernetes-external-secrets"
+#dependencies:
+#  - name: external-secrets
+#    version: "0.6.1"
+#    repository: "https://charts.external-secrets.io"
+#    #"https://external-secrets.github.io/kubernetes-external-secrets"

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -50,11 +50,11 @@ clusterGroup:
       project: hub
       path: common/hashicorp-vault
 
-    # golang-external-secrets:
-    #   name: golang-external-secrets
-    #   namespace: golang-external-secrets
-    #   project: hub
-    #   path: common/golang-external-secrets
+    golang-external-secrets:
+      name: golang-external-secrets
+      namespace: golang-external-secrets
+      project: hub
+      path: common/golang-external-secrets
 
     bobbycar-core-infra:
       name: bobbycar-core-infra


### PR DESCRIPTION
This way it won't fight the ESO installed via the community operator
but we still get the clustersecretstore and the service account that
are used in the imperative namespace to unseal, init and configure
the vault.

This is a short-term approach while we evaluate our more mid/long term
options.

I have tested the multiple ClusterSecretStore object. I did not
test that commenting out the dependencies in Chart.yaml, hopefully
that just works :)
