### PR TITLE
Add golang-external-secret service account

### DIFF
--- a/common/golang-external-secrets/templates/golang-external-secrets-hub-serviceaccount-tmp.yaml
+++ b/common/golang-external-secrets/templates/golang-external-secrets-hub-serviceaccount-tmp.yaml
@@ -1,0 +1,8 @@
+# Temporary service account since we disabled the subchart and the SA is needed
+# by the vault unsealing playbook
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets


### PR DESCRIPTION
Again a temporary workaround since it is created by the subchart we
disabled but it is needed by the vault unseal job
